### PR TITLE
Add `repository` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "component": "component install && component build --use component-builder-suit",
     "component-dev": "component install --dev && component build --dev --use component-builder-suit",
     "preprocess": "suitcss build/build.css build/build.css"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/base.git"
   }
 }


### PR DESCRIPTION
Prevent `npm` from showing the `No repository field` warning.

![](https://cloud.githubusercontent.com/assets/1223565/2908714/d6b8b26e-d62a-11e3-9dc7-1e8a814860c5.png)
## 

@necolas I didn't wanted to basically "spam" you with these types of pull requests, but I think you should add the `repository` field in the `package.json` file of all components. Even if the warnings are harmless, having multiple components, will just make the them [pile up](https://cloud.githubusercontent.com/assets/1223565/2908862/7463f14e-d62c-11e3-8020-cad580ec92df.png), either annoying or confusing the user.
