### PR TITLE
Add input[type=search] selector to box-sizing rule

### DIFF
--- a/lib/base.css
+++ b/lib/base.css
@@ -6,6 +6,7 @@
 /**
  * Prevent margin and border from affecting element width.
  * https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
+ * `input[type="search"]` overrides normalize.css more specific rule.
  */
 
 html {
@@ -14,7 +15,8 @@ html {
 
 *,
 *::before,
-*::after {
+*::after,
+input[type="search"] {
   box-sizing: inherit;
 }
 


### PR DESCRIPTION
More specific rules override more general ones, need to add this to override line 356 of normalize