### PR TITLE
Standardize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,28 @@
 {
   "name": "suitcss-base",
-  "description": "CSS base styles",
   "version": "2.0.0",
-  "style": "index.css",
+  "description": "CSS base styles",
+  "keywords": [
+    "base",
+    "browser",
+    "css",
+    "normalize-css",
+    "suitcss",
+    "style"
+  ],
+  "homepage": "https://github.com/suitcss/base#readme",
+  "bugs": "https://github.com/suitcss/base/labels/bug",
+  "license": "MIT",
+  "author": "Nicolas Gallagher",
   "files": [
     "index.css",
     "index.js",
     "lib"
   ],
-  "dependencies": {
-    "normalize.css": "^4.0.0"
-  },
-  "devDependencies": {
-    "stylelint-config-suitcss": "^5.0.0",
-    "suitcss-components-test": "*",
-    "suitcss-preprocessor": "^1.0.2"
+  "style": "index.css",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/base.git"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",
@@ -26,16 +34,12 @@
     "watch": "npm run preprocess-test -- -w -v",
     "test": "npm run lint"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/suitcss/base.git"
+  "dependencies": {
+    "normalize.css": "^4.0.0"
   },
-  "keywords": [
-    "base",
-    "browser",
-    "css",
-    "normalize-css",
-    "suitcss",
-    "style"
-  ]
+  "devDependencies": {
+    "stylelint-config-suitcss": "^5.0.0",
+    "suitcss-components-test": "*",
+    "suitcss-preprocessor": "^1.0.2"
+  }
 }


### PR DESCRIPTION
I noticed some inconsistencies and omissions in suit package info, so I tidied up:

* Arrange the package objects to match the order found in https://docs.npmjs.com/files/package.json.
* Add a `homepage` object with a link to the project’s readme on GitHub.
* Add a `bugs` object with a link to the project’s issues labeled `bug` on GitHub.
* Add an `author` object with the name of the project’s author.
* Clean up any mistakes or omissions (`"license": "MIT"` appeared twice in `components-grid`s `package.json`)

I have also updated `generator-suit` so that newly-generated suit packages will have these same objects and order.

If these changes are deemed acceptable and desirable by the maintainers, I have branches ready for PR for the remaining 17 @suitcss owned projects.