### PR TITLE
Remove tabindex ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### HEAD
 
 * Update normalize.css to `^8.0.0`.
+* Remove `tabindex=-1` ruleset.
 
 ### 4.0.0 (September 25th, 2017)
 

--- a/lib/base.css
+++ b/lib/base.css
@@ -71,13 +71,3 @@ ul {
   margin: 0;
   padding: 0;
 }
-
-/**
- * Suppress the focus outline on elements that cannot be accessed via keyboard.
- * This prevents an unwanted focus outline from appearing around elements that
- * might still respond to pointer events.
- */
-
-[tabindex="-1"]:focus {
-  outline: none !important;
-}

--- a/test/index.html
+++ b/test/index.html
@@ -20,11 +20,6 @@
   #iframe iframe {
     background-clip: content-box;
   }
-
-  #tabindex a:focus,
-  #tabindex button:focus {
-    outline: 5px solid red;
-  }
 </style>
 
 <div class="Test">
@@ -133,13 +128,6 @@
   <h3 class="Test-it">has no border, margin, or padding</h3>
   <div class="Test-run" id="iframe">
     <iframe class="dev-highlight"></iframe>
-  </div>
-
-  <h2 class="Test-describe">[tabindex="-1"]:focus</h2>
-  <h3 class="Test-it">has no focus outline (try clicking to trigger focus)</h3>
-  <div class="Test-run" id="tabindex">
-    <a class="dev-highlight" href="#n" tabindex="-1">example link</a>
-    <button class="dev-highlight" tabindex="-1">example button</button>
   </div>
 
   <h2 class="Test-describe">border-box</h2>


### PR DESCRIPTION
In connection with #48 `tabindex=-1` CSS ruleset has been removed in order to support visual feedback on programmatically focused elements.